### PR TITLE
binder: don't allow mmap() by process other than proc->tsk

### DIFF
--- a/drivers/staging/android/binder.c
+++ b/drivers/staging/android/binder.c
@@ -3497,7 +3497,7 @@ static int binder_mmap(struct file *filp, struct vm_area_struct *vma)
 	binder_insert_free_buffer(proc, buffer);
 	proc->free_async_space = proc->buffer_size / 2;
 	barrier();
-	proc->files = get_files_struct(proc->tsk);
+	proc->files = get_files_struct(current);
 	proc->vma = vma;
 	proc->vma_vm_mm = vma->vm_mm;
 


### PR DESCRIPTION
we really shouldn't do get_files_struct() on a different process
and use it to modify the sucker later on.

Change-Id: I2be2b99395b6efa85a007317b25e6e9e7953c47a
Signed-off-by: Al Viro <viro@zeniv.linux.org.uk>
Signed-off-by: Kevin F. Haggerty <haggertk@lineageos.org>

# WE DO NOT MERGE PULL REQUESTS SUBMITTED HERE

You will need to submit it through [LineageOS Gerrit](https://review.lineageos.org/#/admin/projects/LineageOS/android_kernel_sony_msm8974)

